### PR TITLE
Add CI workflow and update build docs

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,35 @@
+name: Android CI
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+        with:
+          api-level: '34'
+          build-tools: '34.0.0'
+      - name: Build release APK
+        run: ./gradlew assembleRelease
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release
+          path: app/build/outputs/apk/release/app-release.apk
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: app/build/outputs/apk/release/app-release.apk
+          tag: ${{ github.run_number }}
+          name: "Build ${{ github.run_number }}"
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,16 +1,47 @@
 # ReadAll
 
-This is the initial Android application project. It uses Gradle as the build system and Kotlin for the main source code.
+This project is a minimal Android application built with Kotlin and Gradle.
 
-## Building
+## Development setup
 
-Make sure you have the Android SDK installed and `ANDROID_HOME` set.
+1. Install JDK 21 or later.
+2. Install the Android SDK. Configure the SDK location via the `ANDROID_HOME` environment variable or by creating a `local.properties` file in the project root containing:
+   ```
+   sdk.dir=/path/to/android/sdk
+   ```
 
-To build the project, run:
+## Building the APK
+
+### Debug build
+
+Run the following command to generate a debug APK:
 
 ```bash
 ./gradlew assembleDebug
 ```
 
-The Gradle wrapper JAR will be downloaded automatically on the first run.
-The APK can then be found in `app/build/outputs/apk/debug/`.
+The resulting file will be located at `app/build/outputs/apk/debug/app-debug.apk`.
+
+### Release build
+
+To build a release APK run:
+
+```bash
+./gradlew assembleRelease
+```
+
+The release artifact can be found at `app/build/outputs/apk/release/app-release.apk`.
+
+### Testing
+
+Execute unit tests with:
+
+```bash
+./gradlew test
+```
+
+## CI/CD pipeline
+
+GitHub Actions automatically builds the release APK whenever code is pushed to the `main` branch. The workflow defined in `.github/workflows/android.yml` installs the Android SDK, builds the release variant and uploads the APK as both a workflow artifact and a GitHub release asset.
+
+The generated APK can be downloaded from the workflow run artifacts or the repository's Releases page.


### PR DESCRIPTION
## Summary
- document how to build and test the app
- set up GitHub Actions workflow to build APK and create release on pushes to main

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878c34620ec8322a8860788a5e959fb